### PR TITLE
Fix: Add js file extension for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lnmessage",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Talk to Lightning nodes from your browser",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import {
   JsonRpcErrorResponse,
   Logger,
   CommandoRequest
-} from './types'
+} from './types.js'
 
 const DEFAULT_RECONNECT_ATTEMPTS = 5
 

--- a/src/messages/CommandoMessage.ts
+++ b/src/messages/CommandoMessage.ts
@@ -1,5 +1,5 @@
 import { BufferReader } from './buf.js'
-import { CommandoResponse, JsonRpcErrorResponse, MessageType } from '../types'
+import { CommandoResponse, JsonRpcErrorResponse, MessageType } from '../types.js'
 
 export class CommandoMessage {
   /**

--- a/src/messages/IWireMessage.ts
+++ b/src/messages/IWireMessage.ts
@@ -1,4 +1,4 @@
-import { MessageType } from '../types'
+import { MessageType } from '../types.js'
 
 export interface IWireMessage {
   type: MessageType

--- a/src/messages/InitMessage.ts
+++ b/src/messages/InitMessage.ts
@@ -2,7 +2,7 @@ import { Buffer } from 'buffer'
 import { BufferReader, BufferWriter } from './buf.js'
 import { BitField } from './BitField.js'
 import { InitFeatureFlags } from './InitFeatureFlags.js'
-import { MessageType } from '../types'
+import { MessageType } from '../types.js'
 import { readTlvs } from './read-tlvs.js'
 import { IWireMessage } from './IWireMessage.js'
 

--- a/src/messages/MessageFactory.ts
+++ b/src/messages/MessageFactory.ts
@@ -3,7 +3,7 @@ import { InitMessage } from './InitMessage.js'
 import { PingMessage } from './PingMessage.js'
 import { PongMessage } from './PongMessage.js'
 import { CommandoMessage } from './CommandoMessage.js'
-import { MessageType } from '../types'
+import { MessageType } from '../types.js'
 
 export function deserialize(buffer: Buffer): IWireMessage | { type: number } {
   const type = buffer.readUInt16BE(0)

--- a/src/messages/PingMessage.ts
+++ b/src/messages/PingMessage.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'buffer'
 import { BufferReader, BufferWriter } from './buf.js'
-import { MessageType } from '../types'
+import { MessageType } from '../types.js'
 import { IWireMessage } from './IWireMessage.js'
 
 export const PONG_BYTE_THRESHOLD = 65532

--- a/src/messages/PongMessage.ts
+++ b/src/messages/PongMessage.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'buffer'
 import { BufferReader, BufferWriter } from './buf.js'
-import { MessageType } from '../types'
+import { MessageType } from '../types.js'
 import { IWireMessage } from './IWireMessage.js'
 
 export class PongMessage implements IWireMessage {

--- a/src/noise-state.ts
+++ b/src/noise-state.ts
@@ -1,5 +1,5 @@
 import { ccpDecrypt, ccpEncrypt, ecdh, getPublicKey, hkdf, sha256 } from './crypto.js'
-import type { NoiseStateOptions } from './types'
+import type { NoiseStateOptions } from './types.js'
 import { Buffer } from 'buffer'
 
 export class NoiseState {


### PR DESCRIPTION
- Adds `.js` extension for all imports for `types` to match ESM spec