### PR TITLE
0.0.15 - Fix: Direct Node WS Connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ type LnWebSocketOptions = {
    */
   wsProxy?: string
   /**
+   * When connecting directly to a node, the protocol to use. Defaults to 'wss://'
+   */
+  wsProtocol?: 'ws:' | 'wss:'
+  /**
    * 32 byte hex encoded private key to be used as the local node secret.
    * Use this to ensure a consistent local node identity across connection sessions
    */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lnmessage",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Talk to Lightning nodes from your browser",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,6 @@ import {
   HANDSHAKE_STATE,
   READ_STATE,
   MessageType,
-  JsonRpcRequest,
   JsonRpcSuccessResponse,
   JsonRpcErrorResponse,
   Logger,
@@ -78,7 +77,15 @@ class LnMessage {
   constructor(options: LnWebSocketOptions) {
     validateInit(options)
 
-    const { remoteNodePublicKey, wsProxy, privateKey, ip, port = 9735, logger } = options
+    const {
+      remoteNodePublicKey,
+      wsProxy,
+      wsProtocol = 'wss:',
+      privateKey,
+      ip,
+      port = 9735,
+      logger
+    } = options
 
     this._ls = Buffer.from(privateKey || createRandomPrivateKey(), 'hex')
     this._es = Buffer.from(createRandomPrivateKey(), 'hex')
@@ -91,7 +98,7 @@ class LnMessage {
     this.remoteNodePublicKey = remoteNodePublicKey
     this.publicKey = this.noise.lpk.toString('hex')
     this.privateKey = this._ls.toString('hex')
-    this.wsUrl = wsProxy ? `${wsProxy}/${ip}:${port}` : `wss://${remoteNodePublicKey}@${ip}:${port}`
+    this.wsUrl = wsProxy ? `${wsProxy}/${ip}:${port}` : `${wsProtocol}//${ip}:${port}`
     this.connected$ = new BehaviorSubject<boolean>(false)
     this.connecting = false
     this.Buffer = Buffer

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,10 @@ export type LnWebSocketOptions = {
    */
   wsProxy?: string
   /**
+   * When connecting directly to a node, the protocol to use. Defaults to 'wss://'
+   */
+  wsProtocol?: 'ws:' | 'wss:'
+  /**
    * 32 byte hex encoded private key to be used as the local node secret.
    * Use this to ensure a consistent local node identity across connection sessions
    */

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -10,8 +10,11 @@ export function validateInit(options: LnWebSocketOptions): void {
 
   const ipRegex = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)(\.(?!$)|$)){4}$/
 
-  if (!ip || !ip.match(ipRegex)) {
-    throw new Error(`${ip} is not a valid IP address`)
+  const domainRegex =
+    /^((?!-))(xn--)?[a-z0-9][a-z0-9-_]{0,61}[a-z0-9]{0,1}\.(xn--)?([a-z0-9-]{1,61}|[a-z0-9-]{1,30}\.[a-z]{2,})$/
+
+  if (!ip || !ip.match(ipRegex) || ip.match(domainRegex)) {
+    throw new Error(`${ip} is not a valid IP or DNS address`)
   }
 
   if (!port || port < 1 || port > 65535) {
@@ -20,6 +23,7 @@ export function validateInit(options: LnWebSocketOptions): void {
 
   if (wsProxy) {
     const errMsg = `${wsProxy} is not a valid url`
+
     try {
       const url = new URL(wsProxy)
       if (url.protocol !== 'wss:' && url.protocol !== 'ws:') {


### PR DESCRIPTION
This PR fixes a bug for the WS connection when not connecting through a `wsProxy`. A new init option `wsProtocol` has been added so direct connections can be made with or without TLS.
Also included in this PR is a change that allows as DNS address as well as an IP address.