### PR TITLE
0.0.19-0.1.0: Enhancement - NodeJS Compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lnmessage",
-  "version": "0.0.19",
+  "version": "0.0.19-0.1.0",
   "description": "Talk to Lightning nodes from your browser",
   "main": "dist/index.js",
   "type": "module",
@@ -14,8 +14,9 @@
     "build": "tsc"
   },
   "devDependencies": {
-    "@types/crypto-js": "^4.1.1",
+    "@types/node": "^18.14.0",
     "@types/secp256k1": "^4.0.3",
+    "@types/ws": "^8.5.4",
     "@typescript-eslint/eslint-plugin": "^5.27.0",
     "@typescript-eslint/parser": "^5.27.0",
     "eslint": "^8.16.0",
@@ -24,9 +25,10 @@
     "typescript": "^4.8.2"
   },
   "dependencies": {
+    "@noble/hashes": "^1.2.0",
     "buffer": "^6.0.3",
-    "crypto-js": "^4.1.1",
     "rxjs": "^7.5.7",
-    "secp256k1": "^4.0.3"
+    "secp256k1": "^5.0.0",
+    "ws": "^8.12.1"
   }
 }

--- a/src/chacha/chacha20.ts
+++ b/src/chacha/chacha20.ts
@@ -37,7 +37,7 @@ class Chacha20 {
 
     this.cachePos = 64
     this.buffer = new Uint32Array(16)
-    this.output = new Buffer(64)
+    this.output = Buffer.alloc(64)
   }
 
   quarterRound(a: number, b: number, c: number, d: number) {
@@ -91,7 +91,7 @@ class Chacha20 {
 
   getBytes(len: number) {
     let dpos = 0
-    const dst = new Buffer(len)
+    const dst = Buffer.alloc(len)
     const cacheLen = 64 - this.cachePos
 
     if (cacheLen) {

--- a/src/chacha/index.ts
+++ b/src/chacha/index.ts
@@ -27,7 +27,7 @@ class Cipher {
     }
     this.alen = aad.length
     this.poly.update(aad)
-    const padding = new Buffer(padAmount(this.alen))
+    const padding = Buffer.alloc(padAmount(this.alen))
     if (padding.length) {
       padding.fill(0)
       this.poly.update(padding)
@@ -83,14 +83,14 @@ class Cipher {
       throw new Error('Unsupported state or unable to authenticate data')
     }
 
-    const padding = new Buffer(padAmount(this.clen))
+    const padding = Buffer.alloc(padAmount(this.clen))
 
     if (padding.length) {
       padding.fill(0)
       this.poly.update(padding)
     }
 
-    const lens = new Buffer(16)
+    const lens = Buffer.alloc(16)
     lens.fill(0)
     lens.writeUInt32LE(this.alen, 0)
     lens.writeUInt32LE(this.clen, 8)
@@ -110,7 +110,7 @@ class Cipher {
 
   getAuthTag() {
     if (this._decrypt || this.tag === null) {
-      return new Buffer('')
+      return Buffer.from('')
     }
     return this.tag
   }

--- a/src/chacha/poly1305.ts
+++ b/src/chacha/poly1305.ts
@@ -9,7 +9,7 @@ class Poly1305 {
   public finished: number
 
   constructor(key: Buffer) {
-    this.buffer = new Buffer(16)
+    this.buffer = Buffer.alloc(16)
     this.leftover = 0
     this.r = new Uint16Array(10)
     this.h = new Uint16Array(10)
@@ -126,7 +126,7 @@ class Poly1305 {
   }
 
   finish() {
-    let mac = new Buffer(16),
+    let mac = Buffer.alloc(16),
       g = new Uint16Array(10),
       c = 0,
       mask = 0,

--- a/src/index.ts
+++ b/src/index.ts
@@ -397,7 +397,7 @@ class LnMessage {
               this._partialCommandoMsgs[requestId],
               message.subarray(0, message.byteLength - 16)
             ])
-          : Buffer.from(decrypted.subarray(0, decrypted.length - 16))
+          : decrypted.subarray(0, decrypted.length - 16)
 
         return
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { Buffer } from 'buffer'
+
 export type LnWebSocketOptions = {
   /**
    * 33-byte hex remote compressed public key.

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,6 +41,11 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@noble/hashes@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.2.0.tgz#a3150eeb09cc7ab207ebf6d7b9ad311a9bdbed12"
+  integrity sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -62,25 +67,27 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@types/crypto-js@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.1.1.tgz#602859584cecc91894eb23a4892f38cfa927890d"
-  integrity sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==
-
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
-"@types/node@*":
-  version "18.7.21"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.21.tgz#63ee6688070e456325b6748dc492a7b948593871"
-  integrity sha512-rLFzK5bhM0YPyCoTC8bolBjMk7bwnZ8qeZUBslBfjZQou2ssJdWslx9CZ8DGM+Dx7QXQiiTVZ/6QO6kwtHkZCA==
+"@types/node@*", "@types/node@^18.14.0":
+  version "18.14.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.0.tgz#94c47b9217bbac49d4a67a967fdcdeed89ebb7d0"
+  integrity sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==
 
 "@types/secp256k1@^4.0.3":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@types/secp256k1/-/secp256k1-4.0.3.tgz#1b8e55d8e00f08ee7220b4d59a6abe89c37a901c"
   integrity sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==
+  dependencies:
+    "@types/node" "*"
+
+"@types/ws@^8.5.4":
+  version "8.5.4"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.4.tgz#bb10e36116d6e570dd943735f86c933c1587b8a5"
+  integrity sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==
   dependencies:
     "@types/node" "*"
 
@@ -287,11 +294,6 @@ cross-spawn@^7.0.2:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-crypto-js@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
-  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
 debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
@@ -750,15 +752,15 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-node-addon-api@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
-  integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
+node-addon-api@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
+  integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
 
 node-gyp-build@^4.2.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.5.0.tgz#7a64eefa0b21112f89f58379da128ac177f20e40"
-  integrity sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.6.0.tgz#0c52e4cbf54bbd28b709820ef7b6a3c2d6209055"
+  integrity sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==
 
 once@^1.3.0:
   version "1.4.0"
@@ -881,13 +883,13 @@ rxjs@^7.5.7:
   dependencies:
     tslib "^2.1.0"
 
-secp256k1@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.3.tgz#c4559ecd1b8d3c1827ed2d1b94190d69ce267303"
-  integrity sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==
+secp256k1@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-5.0.0.tgz#be6f0c8c7722e2481e9773336d351de8cddd12f7"
+  integrity sha512-TKWX8xvoGHrxVdqbYeZM9w+izTF4b9z3NhSaDkdn81btvuh+ivbIMGT/zQvDtTFWhRlThpoz6LEYTr7n8A5GcA==
   dependencies:
     elliptic "^6.5.4"
-    node-addon-api "^2.0.0"
+    node-addon-api "^5.0.0"
     node-gyp-build "^4.2.0"
 
 semver@^7.3.7:
@@ -1002,6 +1004,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@^8.12.1:
+  version "8.12.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.1.tgz#c51e583d79140b5e42e39be48c934131942d4a8f"
+  integrity sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This PR makes Lnmessage work in both NodeJS and the Browser without any polyfilling necessary.

- Remove CryptoJS dependency
- Add `@noble/hashes` dependency to replace CryptoJS and browser crypto
- Add `ws` dependency and dynamically load it if not in a browser environment. So browsers will not load this dep in to their bundler
- Fix deprecated usage of Buffer()
- Remove `async` and `await` keywords as the new SHA256 function is synchronous

Fixes #3 