### PR TITLE
fix: support SW usage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,9 +159,9 @@ class LnMessage {
     this.connectionStatus$.next('connecting')
     this._attemptReconnect = attemptReconnect
 
-    this.socket = new (
-      typeof window === 'undefined' ? (await import('ws')).default : window.WebSocket
-    )(this.wsUrl)
+    // https://stackoverflow.com/questions/17575790/environment-detection-node-js-or-browser#comment120214255_31456668
+    const isNode = typeof process !== 'undefined' && process?.versions?.node
+    this.socket = new (isNode ? (await import('ws')).default : WebSocket)(this.wsUrl)
     this.socket.binaryType = 'arraybuffer'
 
     this.socket.onopen = async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,9 +159,7 @@ class LnMessage {
     this.connectionStatus$.next('connecting')
     this._attemptReconnect = attemptReconnect
 
-    // https://stackoverflow.com/questions/17575790/environment-detection-node-js-or-browser#comment120214255_31456668
-    const isNode = typeof process !== 'undefined' && process?.versions?.node
-    this.socket = new (isNode ? (await import('ws')).default : WebSocket)(this.wsUrl)
+    this.socket =  new (typeof globalThis.WebSocket === 'undefined' ? (await import('ws')).default : globalThis.WebSocket)(this.wsUrl)
     this.socket.binaryType = 'arraybuffer'
 
     this.socket.onopen = async () => {


### PR DESCRIPTION
We stumbled across [this issue](https://github.com/getAlby/lightning-browser-extension/pull/1124#issuecomment-1476409179) in our PR switching the extension to manifest version 3 (MV3).  

In MV3 the code is running within a service worker so no `window` exitsts. Not exactly sure where the `document` error is coming from but with thsi change it works.

What do you think? Would this work for all use cases?

