### PR TITLE
0.2.5-0.0.1 - Fix: TCP Socket Wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lnmessage",
-  "version": "0.2.5",
+  "version": "0.2.5-0.0.1",
   "description": "Talk to Lightning nodes from your browser",
   "main": "dist/index.js",
   "type": "module",

--- a/src/socket-wrapper.ts
+++ b/src/socket-wrapper.ts
@@ -17,6 +17,7 @@ class SocketWrapper {
 
     socket.on('close', () => {
       this.onclose && this.onclose()
+      socket.removeAllListeners()
     })
 
     socket.on('error', (error) => {
@@ -32,8 +33,7 @@ class SocketWrapper {
     }
 
     this.close = () => {
-      socket.removeAllListeners()
-      socket.destroy()
+      socket.end()
     }
 
     const url = new URL(connection)


### PR DESCRIPTION
- Fixes the close handling on the TCP socket wrapper to gracefully close using the `end` method, and then only removing listeners once the close event fires.