### PR TITLE
Add connection status as failed to return after maximum failed attempts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lnmessage",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Talk to Lightning nodes from your browser",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ class LnMessage {
   public connected$: BehaviorSubject<boolean>
   /**
    * Observable that indicates the current socket connection status
-   * Can be either 'connected', 'connecting', 'waiting_reconnect' or 'disconnected'.
+   * Can be either 'connected', 'connecting', 'waiting_reconnect', 'disconnected' or 'failed'.
    */
   public connectionStatus$: BehaviorSubject<ConnectionStatus>
   /**
@@ -214,6 +214,9 @@ class LnMessage {
 
         this.connect()
         this._attemptedReconnects += 1
+      } else if (this._attemptReconnect && this._attemptedReconnects >= DEFAULT_RECONNECT_ATTEMPTS) {
+        this._log('error', `Failed to reconnect after ${DEFAULT_RECONNECT_ATTEMPTS} attempts`);
+        this.connectionStatus$.next('failed');
       }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,4 +189,4 @@ export type Logger = {
   error: (msg: string) => void
 }
 
-export type ConnectionStatus = 'connected' | 'connecting' | 'disconnected' | 'waiting_reconnect'
+export type ConnectionStatus = 'connected' | 'connecting' | 'disconnected' | 'waiting_reconnect' | 'failed'


### PR DESCRIPTION
Add a `failed` connection status observer so the client can detect when re-connection has permanently failed after five retries, rather than treating it as a generic `disconnected` state.